### PR TITLE
Removed cohort tags transfer. Eg: "SG9"

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -85,7 +85,6 @@ CARRY_FORWARD_TAGS = [
   /^li-/,     # tags starting li- for LinkedIn
   /-li-/,     # tags containing -li- for LinkedIn
   /[a-zA-Z]{2}[0-9]+-/,   # tags starting with a cohort code e.g. sg9-
-  /[a-zA-Z]{2}[0-9]+$/,   # tags of cohort code e.g. "SG9"
   /^lead score:/i,
   /[0-9]+sourced/i,
 


### PR DESCRIPTION
Not needed, tags get too messy.